### PR TITLE
fix java logo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,8 +356,9 @@
                     <div class="cardissue">
                       <div class="cardcontentissue">
                         <a href="https://goodfirstissue.dev/language/java" class="java-link" data-toggle="modal">
-
-                        <img src="https://assets.stickpng.com/images/58480979cef1014c0b5e4901.png" height="150px" width="150px" class="text-center imageissue"/>
+                        
+                        <!--IMAGE CREDIT DUE TO SEEKLOGO.COM-->
+                        <img src="https://seeklogo.com/images/J/java-logo-7833D1D21A-seeklogo.com.png" height="150px" width="150px" class="text-center imageissue"/>
                         </a>
                         <h3 class="headerissue">Java</h3>
                       </div>


### PR DESCRIPTION
Fixing the broken image link under the Java section by replacing with another url. (Also added a credit line for the source of the image in the HTML comments). 